### PR TITLE
Passing an ArrayBuffer to new Buffer() is efficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@
 Say you're using the ['buffer'](https://github.com/feross/buffer) module on npm, or
 [browserify](http://browserify.org/) and you're working with lots of binary data.
 
-Unfortunately, sometimes the browser or someone else's API gives you an `ArrayBuffer`
-or a typed array like `Uint8Array` to work with and you need to convert it to a
-`Buffer`. What do you do?
+Unfortunately, sometimes the browser or someone else's API gives you a typed array
+like `Uint8Array` to work with and you need to convert it to a `Buffer`. What do you do?
 
 Of course: `new Buffer(uint8array)`
 
@@ -30,6 +29,9 @@ So, how can we avoid this expensive copy in
 [performance critical applications](https://github.com/feross/buffer/issues/22)?
 
 ***Simply use this module, of course!***
+
+If you have an `ArrayBuffer`, you don't need this module, because `new Buffer(arrayBuffer)`
+[is already efficient](https://nodejs.org/api/buffer.html#buffer_new_buffer_arraybuffer).
 
 ## install
 

--- a/index.js
+++ b/index.js
@@ -6,28 +6,25 @@
  *
  * `npm install typedarray-to-buffer`
  */
- /* eslint-disable no-proto */
 
 var isTypedArray = require('is-typedarray').strict
 
 module.exports = function (arr) {
   // If `Buffer` is the browser `buffer` module, and the browser supports typed arrays,
   // then avoid a copy. Otherwise, create a `Buffer` with a copy.
-  var constructor = Buffer.TYPED_ARRAY_SUPPORT
-    ? function (arr) {
-      arr.__proto__ = Buffer.prototype
-      return arr
+  if (isTypedArray(arr)) {
+    if (!Buffer.TYPED_ARRAY_SUPPORT) {
+      // This is not faster than new Buffer(arr), but it has different semantics,
+      // because it uses 4 bytes instead of one per element for Uint32Array.
+      return new Buffer(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength))
     }
-    : function (arr) { return new Buffer(arr) }
-
-  if (arr instanceof Uint8Array) {
-    return constructor(arr)
-  } else if (arr instanceof ArrayBuffer) {
-    return constructor(new Uint8Array(arr))
-  } else if (isTypedArray(arr)) {
     // Use the typed array's underlying ArrayBuffer to back new Buffer. This respects
     // the "view" on the ArrayBuffer, i.e. byteOffset and byteLength. No copy.
-    return constructor(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength))
+    var buffer = new Buffer(arr.buffer)
+    if (arr.byteLength !== buffer.length) {
+      buffer = buffer.slice(arr.byteOffset, arr.byteOffset + arr.byteLength)
+    }
+    return buffer
   } else {
     // Unsupported type, just pass it through to the `Buffer` constructor.
     return new Buffer(arr)


### PR DESCRIPTION
`new Buffer(arrayBuffer)` [does not copy](https://nodejs.org/api/buffer.html#buffer_new_buffer_arraybuffer).

Now this module is independent from any `buffer` internals, and you don't need to update whenever `buffer` changes.
